### PR TITLE
chore: update to lezer-fiz 0.2.5

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@formulavize/lang-fiz",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@formulavize/lang-fiz",
-      "version": "0.2.4",
+      "version": "0.2.5",
       "license": "MIT",
       "dependencies": {
         "@codemirror/language": "^6.10.1",
@@ -260,9 +260,9 @@
       }
     },
     "node_modules/@formulavize/lezer-fiz": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@formulavize/lezer-fiz/-/lezer-fiz-0.2.4.tgz",
-      "integrity": "sha512-3y1Z7RpMPwx+Y3R68GB48msj71PblFCEsgIvYs7cT4Ss6TqIGv34lx48vQi1JM2ZHG249PT7GubxtsdGxdqG8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@formulavize/lezer-fiz/-/lezer-fiz-0.2.5.tgz",
+      "integrity": "sha512-w0JhcMXGfkXpbmhLIGV4+9yDYGNjI/VR3hotPhh3okiTVIUDuiubMxPVi0k4pdZVCf/ZE3/lXvNVA9eHND87fw==",
       "dependencies": {
         "@lezer/highlight": "^1.2.0",
         "@lezer/lr": "^1.4.0"
@@ -3697,9 +3697,9 @@
       }
     },
     "@formulavize/lezer-fiz": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/@formulavize/lezer-fiz/-/lezer-fiz-0.2.4.tgz",
-      "integrity": "sha512-3y1Z7RpMPwx+Y3R68GB48msj71PblFCEsgIvYs7cT4Ss6TqIGv34lx48vQi1JM2ZHG249PT7GubxtsdGxdqG8w==",
+      "version": "0.2.5",
+      "resolved": "https://registry.npmjs.org/@formulavize/lezer-fiz/-/lezer-fiz-0.2.5.tgz",
+      "integrity": "sha512-w0JhcMXGfkXpbmhLIGV4+9yDYGNjI/VR3hotPhh3okiTVIUDuiubMxPVi0k4pdZVCf/ZE3/lXvNVA9eHND87fw==",
       "requires": {
         "@lezer/highlight": "^1.2.0",
         "@lezer/lr": "^1.4.0"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@formulavize/lang-fiz",
-  "version": "0.2.4",
+  "version": "0.2.5",
   "description": "fiz language support for CodeMirror",
   "scripts": {
     "build": "cm-buildhelper src/index.ts",


### PR DESCRIPTION
update to lezer-fiz 0.2.5 to include the change allowing namespaces in assignment expressions